### PR TITLE
JSP templates emit whitespace that messes with file downloads.

### DIFF
--- a/savefile.jsp
+++ b/savefile.jsp
@@ -1,4 +1,5 @@
 <%@include file="util.jsp"%>
+<%@ page trimDirectiveWhitespaces="true" %>
 <%
     if (request.getParameter("file").endsWith("xml")) {
         response.setContentType("text/xml");


### PR DESCRIPTION
It is apparently a JSP-thing to do this, but there's a directive
that can be added to prevent it. This commit adds that directive.